### PR TITLE
Bump versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ mod_version = 1.5.0
 group = net.shadowfacts
 archivesBaseName = Forgelin
 
-mc_version = 1.10.2
-mcp_mappings = snapshot_20160802
-forge_version = 12.18.1.2045
+mc_version = 1.12
+mcp_mappings = snapshot_20170624
+forge_version = 14.21.0.2368
 
-kotlin_version = 1.1.2-4
+kotlin_version = 1.1.3
 annotations_version = 15.0
-coroutines_version = 0.14.1
+coroutines_version = 0.16


### PR DESCRIPTION
I've bumped the following versions:

- Minecraft (to 1.12)
- Forge (to 14.21.0.2368)
- MCP Mappings (to snapshot_20170624)
- Kotlin (to 1.1.3)
- Kotlin Coroutines (to 0.16)
- Jetbrains Annotations (to 15.0)

I haven't bumped the mod version though, so if you could bump that and release a new version it would be greatly appreciated.