### PR TITLE
Remove custom Kotlin source replacement code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,25 +89,6 @@ shadowJar {
 
 tasks.build.dependsOn shadowJar
 
-import net.minecraftforge.gradle.user.TaskSourceCopy
-
-// Enables source replacements for Kotlin code
-for (set in sourceSets) {
-	def taskName = "source${set.name.capitalize()}Kotlin"
-	def dir = new File(project.getBuildDir(), "sources/${set.name}/kotlin")
-	task(taskName, type: TaskSourceCopy) {
-		source = set.getKotlin()
-		output = dir
-	}
-	def compileTask = tasks[set.getCompileTaskName("kotlin")]
-	compileTask.source = dir
-	compileTask.dependsOn taskName
-	def dirPath = dir.toPath()
-	compileKotlin.include {
-		return it.file.toPath().startsWith(dirPath)
-	}
-}
-
 artifacts {
 	archives shadowJar
 }


### PR DESCRIPTION
My Pull Request to ForgeGradle was merged, it now "natively" supports Kotlin source replacements. It should now be safe to remove the custom source replacement code in favour of the FG solution. Note that you might have to run builds with the `--refresh-dependencies` flag for this to be noticeable.