### PR TITLE
Object EventBusSubscriber registration

### DIFF
--- a/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
@@ -4,7 +4,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler
 import net.minecraftforge.fml.common.Loader
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
+import net.minecraftforge.fml.common.event.FMLConstructionEvent
 
 /**
  * @author shadowfacts
@@ -17,9 +17,9 @@ object Forgelin {
 	const val VERSION = "@VERSION@"
 
 	@EventHandler
-	fun onPreInit(event: FMLPreInitializationEvent) {
+	fun onPreInit(event: FMLConstructionEvent) {
 		Loader.instance().modList.forEach {
-			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmData, FMLCommonHandler.instance().side)
+			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmHarvestedData, FMLCommonHandler.instance().side)
 		}
 	}
 }

--- a/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
@@ -1,6 +1,10 @@
 package net.shadowfacts.forgelin
 
+import net.minecraftforge.fml.common.FMLCommonHandler
+import net.minecraftforge.fml.common.Loader
 import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.common.Mod.EventHandler
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 
 /**
  * @author shadowfacts
@@ -12,4 +16,10 @@ object Forgelin {
 	const val NAME = "Forgelin"
 	const val VERSION = "@VERSION@"
 
+	@EventHandler
+	fun onPreInit(event: FMLPreInitializationEvent) {
+		Loader.instance().modList.forEach {
+			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmData, FMLCommonHandler.instance().side)
+		}
+	}
 }

--- a/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
@@ -17,7 +17,7 @@ object Forgelin {
 	const val VERSION = "@VERSION@"
 
 	@EventHandler
-	fun onPreInit(event: FMLConstructionEvent) {
+	fun onConstruction(event: FMLConstructionEvent) {
 		Loader.instance().modList.forEach {
 			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmHarvestedData, FMLCommonHandler.instance().side)
 		}

--- a/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
@@ -11,6 +11,7 @@ import net.minecraftforge.fml.common.discovery.asm.ModAnnotation.EnumHolder
 import net.minecraftforge.fml.relauncher.Side
 import org.apache.logging.log4j.LogManager
 import java.util.EnumSet
+import kotlin.reflect.full.companionObjectInstance
 
 object ForgelinAutomaticEventSubscriber {
     private val DEFAULT_SUBSCRIPTION_SIDES = EnumSet.allOf(Side::class.java)
@@ -40,10 +41,13 @@ object ForgelinAutomaticEventSubscriber {
 
                 LOGGER.debug("Registering @EventBusSubscriber object for {} for mod {}", subscriber.className, mod.modId)
 
-                val subscriberInstance = Class.forName(subscriber.className, false, loader)?.kotlin?.objectInstance
-                if (subscriberInstance != null) {
-                    MinecraftForge.EVENT_BUS.register(subscriberInstance)
-                    LOGGER.debug("Registered @EventBusSubscriber object {}", subscriber.className)
+                val subscriberClass = Class.forName(subscriber.className, false, loader)?.kotlin
+                if (subscriberClass != null) {
+                    val subscriberInstance = subscriberClass.objectInstance ?: subscriberClass.companionObjectInstance
+                    if (subscriberInstance != null) {
+                        MinecraftForge.EVENT_BUS.register(subscriberInstance)
+                        LOGGER.debug("Registered @EventBusSubscriber object {}", subscriber.className)
+                    }
                 }
             } catch (e: Throwable) {
                 LOGGER.error("An error occurred trying to load an @EventBusSubscriber object {} for modid {}", mod.modId, e)

--- a/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
@@ -1,0 +1,75 @@
+package net.shadowfacts.forgelin
+
+import net.minecraftforge.common.MinecraftForge
+import net.minecraftforge.fml.common.Loader
+import net.minecraftforge.fml.common.LoaderException
+import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.common.ModContainer
+import net.minecraftforge.fml.common.discovery.ASMDataTable
+import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData
+import net.minecraftforge.fml.common.discovery.asm.ModAnnotation.EnumHolder
+import net.minecraftforge.fml.relauncher.Side
+import org.apache.logging.log4j.LogManager
+import java.util.EnumSet
+
+object ForgelinAutomaticEventSubscriber {
+    private val DEFAULT_SUBSCRIPTION_SIDES = EnumSet.allOf(Side::class.java)
+    private val LOGGER = LogManager.getLogger(ForgelinAutomaticEventSubscriber::class.java)
+
+    fun subscribeAutomatic(mod: ModContainer, asm: ASMDataTable, currentSide: Side) {
+        LOGGER.debug("Attempting to register Kotlin @EventBusSubscriber objects for {}", mod.modId)
+
+        val modAnnotations = asm.getAnnotationsFor(mod) ?: return
+
+        val containedMods = modAnnotations.get(Mod::class.java.name)
+        val subscribers = modAnnotations.get(Mod.EventBusSubscriber::class.java.name)
+        val loader = Loader.instance().modClassLoader
+
+        for (subscriber in subscribers.filter { parseTargetSides(it).contains(currentSide) }) {
+            try {
+                val ownerModId = parseModId(containedMods, subscriber)
+                if (ownerModId.isNullOrEmpty()) {
+                    LOGGER.warn("Could not determine owning mod for @EventBusSubscriber on {} for mod {}", subscriber.className, mod.modId)
+                    continue
+                }
+
+                if (mod.modId != ownerModId) {
+                    LOGGER.debug("Skipping @EventBusSubscriber injection for {} since it is not for mod {}", subscriber.className, mod.modId)
+                    continue
+                }
+
+                LOGGER.debug("Registering @EventBusSubscriber object for {} for mod {}", subscriber.className, mod.modId)
+
+                val subscriberInstance = Class.forName(subscriber.className, false, loader)?.kotlin?.objectInstance
+                if (subscriberInstance != null) {
+                    MinecraftForge.EVENT_BUS.register(subscriberInstance)
+                    LOGGER.debug("Registered @EventBusSubscriber object {}", subscriber.className)
+                }
+            } catch (e: Throwable) {
+                LOGGER.error("An error occurred trying to load an @EventBusSubscriber object {} for modid {}", mod.modId, e)
+                throw LoaderException(e)
+            }
+        }
+    }
+
+    private fun parseModId(containedMods: MutableSet<ASMData>, subscriber: ASMData): String? {
+        val parsedModId: String? = subscriber.annotationInfo["modid"] as? String
+        if (parsedModId.isNullOrEmpty()) {
+            return parsedModId
+        }
+
+        return ASMDataTable.getOwnerModID(containedMods, subscriber)
+    }
+
+    private fun parseTargetSides(subscriber: ASMData): EnumSet<Side> {
+        val parsedSides: List<EnumHolder>? = subscriber.annotationInfo["value"] as? List<EnumHolder>
+        if (parsedSides != null) {
+            val targetSides = EnumSet.noneOf(Side::class.java)
+            for (parsed in parsedSides) {
+                targetSides.add(Side.valueOf(parsed.value))
+            }
+            return targetSides
+        }
+        return DEFAULT_SUBSCRIPTION_SIDES
+    }
+}

--- a/src/test/kotlin/net/shadowfacts/forgelin/AutomaticKtSubscriberTest.kt
+++ b/src/test/kotlin/net/shadowfacts/forgelin/AutomaticKtSubscriberTest.kt
@@ -1,0 +1,19 @@
+package net.shadowfacts.forgelin
+
+import net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock
+import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@Mod(modid = AutomaticKtSubscriberTest.MODID, modLanguageAdapter = "net.shadowfacts.forgelin.KotlinAdapter")
+object AutomaticKtSubscriberTest {
+    const val MODID = "ktsubtest"
+
+    @EventBusSubscriber(modid = AutomaticKtSubscriberTest.MODID)
+    object EventSubscriber {
+        @SubscribeEvent
+        fun onRightClickBlock(event: RightClickBlock) {
+            println("Automatic KT subscriber: Right click ${event.pos}")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a scanner for all Kotlin objects with the `EventBusSubscriber` annotation and registers them to the event bus.

I'm not too sure about how this is implemented, or if this is something that should be apart of Forgelin (it seems like nothing like this will make it into Forge itself).
Any feedback appreciated!

EDIT: Also, should this expand to object holders and configs? Should that be apart of a different PR?