### PR TITLE
Unregister class reference from the event bus

### DIFF
--- a/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
@@ -43,8 +43,9 @@ object ForgelinAutomaticEventSubscriber {
 
                 LOGGER.debug("Registering @EventBusSubscriber object for {} for mod {}", subscriber.className, mod.modId)
 
-                val subscriberClass = Class.forName(subscriber.className, false, loader)?.kotlin ?: continue
-                val subscriberInstance = subscriberClass.objectInstance ?: subscriberClass.companionObjectInstance ?: continue
+                val subscriberClass = Class.forName(subscriber.className, false, loader) ?: continue
+                val kotlinClass = subscriberClass?.kotlin ?: continue
+                val subscriberInstance = kotlinClass.objectInstance ?: kotlinClass.companionObjectInstance ?: continue
 
                 MinecraftForge.EVENT_BUS.unregister(subscriberClass)
                 MinecraftForge.EVENT_BUS.register(subscriberInstance)

--- a/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/ForgelinAutomaticEventSubscriber.kt
@@ -46,6 +46,7 @@ object ForgelinAutomaticEventSubscriber {
                 val subscriberClass = Class.forName(subscriber.className, false, loader)?.kotlin ?: continue
                 val subscriberInstance = subscriberClass.objectInstance ?: subscriberClass.companionObjectInstance ?: continue
 
+                MinecraftForge.EVENT_BUS.unregister(subscriberClass)
                 MinecraftForge.EVENT_BUS.register(subscriberInstance)
                 LOGGER.debug("Registered @EventBusSubscriber object {}", subscriber.className)
             } catch (e: Throwable) {


### PR DESCRIPTION
When Forgelin registers the object instance of an `@EventBusSubscriber` annotated object class to the event bus, it does not unregister the static class reference that Forge will have registered before Forgelin parses the annotation candidates. This could potentially cause issues, and breaks expectations/semantics from having the annotation register a class both statically and as an instance. This pull request adds a call to `MinecraftForge.EVENT_BUS#unregister` to remove the Forge-registered class reference before registering the instance reference.