### PR TITLE
Fix #38

### DIFF
--- a/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
@@ -4,7 +4,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler
 import net.minecraftforge.fml.common.Loader
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventHandler
-import net.minecraftforge.fml.common.event.FMLConstructionEvent
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
 
 /**
  * @author shadowfacts
@@ -17,9 +17,9 @@ object Forgelin {
 	const val VERSION = "@VERSION@"
 
 	@EventHandler
-	fun onConstruction(event: FMLConstructionEvent) {
+	fun onPreInit(event: FMLPreInitializationEvent) {
 		Loader.instance().modList.forEach {
-			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmHarvestedData, FMLCommonHandler.instance().side)
+			ForgelinAutomaticEventSubscriber.subscribeAutomatic(it, event.asmData, FMLCommonHandler.instance().side)
 		}
 	}
 }


### PR DESCRIPTION
Because the automatic subscriber depends on the mod class loader, we need it to run after that has been initialized. That only happens in the construction event, so we have to search at some later stage.