### PR TITLE
update to 1.3.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Fork of [Emberwalker's Forgelin](https://github.com/Emberwalker/Forgelin).
 
 ## Additions
-- Shades the Kotlin standard library, runtime, and reflect libraries so you don't have to.
+- Shades the Kotlin standard library, runtime, coroutines-core, and reflect libraries so you don't have to.
 - Provides a Forge `ILanguageAdapter` for using Kotlin `object` classes as your main mod class.
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 			name "forge"
 			url "http://files.minecraftforge.net/maven/"
 		}
+		maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 	}
 	dependencies {
 		classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
@@ -53,6 +54,7 @@ processResources {
 
 repositories {
 	jcenter()
+	maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 			name "forge"
 			url "http://files.minecraftforge.net/maven/"
 		}
-		maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 	}
 	dependencies {
 		classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
@@ -54,7 +53,6 @@ processResources {
 
 repositories {
 	jcenter()
-	maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-mod_version = 1.8.2
+mod_version = 1.8.3
 group = net.shadowfacts
 archivesBaseName = Forgelin
 
@@ -6,6 +6,6 @@ mc_version = 1.12.2
 mcp_mappings = snapshot_20180609
 forge_version = 14.23.4.2705
 
-kotlin_version = 1.3.10
+kotlin_version = 1.3.40-eap-32
 annotations_version = 16.0.3
-coroutines_version = 1.0.1
+coroutines_version = 1.2.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ mc_version = 1.12.2
 mcp_mappings = snapshot_20180609
 forge_version = 14.23.4.2705
 
-kotlin_version = 1.3.40-eap-32
+kotlin_version = 1.3.40
 annotations_version = 16.0.3
 coroutines_version = 1.2.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
skipped current stable (1.3.31) because of https://youtrack.jetbrains.com/issue/KT-30132

feel free to keep this open until kotlin 1.3.40 releases, i will update the PR then
or maybe think of some other fix for KT-30132

fow now i guess its WIP because no other forgelin version is for eap versions